### PR TITLE
Change endpoint to current endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ app.use(bodyParser.json());
 
 
 // URLs to be used
-const BASE_URL = 'https://servers-frontend.fivem.net/api/servers';
+const BASE_URL = 'https://frontend.cfx-services.net/api/servers';
 const ALL_SERVERS_URL = `${BASE_URL}/streamRedir/`;
 
 


### PR DESCRIPTION
Since FiveM had moved it's streamRedir endpoint to a new address the base URL has to be changed in order for it to not crash on start.